### PR TITLE
Allow user to rename backup of database.

### DIFF
--- a/src/DataButler/Backup.Designer.cs
+++ b/src/DataButler/Backup.Designer.cs
@@ -68,7 +68,7 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(160, 9);
+            this.label1.Location = new System.Drawing.Point(173, 9);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(47, 13);
             this.label1.TabIndex = 9;
@@ -76,7 +76,7 @@
             // 
             // btnBackup
             // 
-            this.btnBackup.Location = new System.Drawing.Point(322, 97);
+            this.btnBackup.Location = new System.Drawing.Point(313, 97);
             this.btnBackup.Name = "btnBackup";
             this.btnBackup.Size = new System.Drawing.Size(113, 33);
             this.btnBackup.TabIndex = 8;
@@ -87,7 +87,7 @@
             // pictureBox1
             // 
             this.pictureBox1.Image = global::DataButler.Properties.Resources.Loading;
-            this.pictureBox1.Location = new System.Drawing.Point(419, 31);
+            this.pictureBox1.Location = new System.Drawing.Point(432, 31);
             this.pictureBox1.Name = "pictureBox1";
             this.pictureBox1.Size = new System.Drawing.Size(16, 16);
             this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
@@ -109,7 +109,7 @@
             this.cbDatabase.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cbDatabase.Font = new System.Drawing.Font("MS Reference Sans Serif", 12F);
             this.cbDatabase.FormattingEnabled = true;
-            this.cbDatabase.Location = new System.Drawing.Point(163, 25);
+            this.cbDatabase.Location = new System.Drawing.Point(176, 25);
             this.cbDatabase.Name = "cbDatabase";
             this.cbDatabase.Size = new System.Drawing.Size(250, 28);
             this.cbDatabase.TabIndex = 12;
@@ -117,7 +117,7 @@
             // 
             // txtBackupAs
             // 
-            this.txtBackupAs.Location = new System.Drawing.Point(160, 71);
+            this.txtBackupAs.Location = new System.Drawing.Point(176, 71);
             this.txtBackupAs.Name = "txtBackupAs";
             this.txtBackupAs.Size = new System.Drawing.Size(250, 20);
             this.txtBackupAs.TabIndex = 13;
@@ -125,7 +125,7 @@
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(160, 56);
+            this.label2.Location = new System.Drawing.Point(173, 56);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(62, 13);
             this.label2.TabIndex = 14;

--- a/src/DataButler/Backup.Designer.cs
+++ b/src/DataButler/Backup.Designer.cs
@@ -36,6 +36,8 @@
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.WaitImage = new System.Windows.Forms.PictureBox();
             this.cbDatabase = new System.Windows.Forms.ComboBox();
+            this.txtBackupAs = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.WaitImage)).BeginInit();
             this.SuspendLayout();
@@ -54,12 +56,12 @@
             // txtLog
             // 
             this.txtLog.BackColor = System.Drawing.SystemColors.Window;
-            this.txtLog.Location = new System.Drawing.Point(163, 96);
+            this.txtLog.Location = new System.Drawing.Point(163, 136);
             this.txtLog.Multiline = true;
             this.txtLog.Name = "txtLog";
             this.txtLog.ReadOnly = true;
             this.txtLog.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.txtLog.Size = new System.Drawing.Size(272, 96);
+            this.txtLog.Size = new System.Drawing.Size(272, 56);
             this.txtLog.TabIndex = 10;
             this.txtLog.Visible = false;
             // 
@@ -74,7 +76,7 @@
             // 
             // btnBackup
             // 
-            this.btnBackup.Location = new System.Drawing.Point(302, 58);
+            this.btnBackup.Location = new System.Drawing.Point(322, 97);
             this.btnBackup.Name = "btnBackup";
             this.btnBackup.Size = new System.Drawing.Size(113, 33);
             this.btnBackup.TabIndex = 8;
@@ -113,11 +115,29 @@
             this.cbDatabase.TabIndex = 12;
             this.cbDatabase.SelectionChangeCommitted += new System.EventHandler(this.DatabaseSelected);
             // 
+            // txtBackupAs
+            // 
+            this.txtBackupAs.Location = new System.Drawing.Point(160, 71);
+            this.txtBackupAs.Name = "txtBackupAs";
+            this.txtBackupAs.Size = new System.Drawing.Size(250, 20);
+            this.txtBackupAs.TabIndex = 13;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(160, 56);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(62, 13);
+            this.label2.TabIndex = 14;
+            this.label2.Text = "Backup As:";
+            // 
             // Backup
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(451, 199);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.txtBackupAs);
             this.Controls.Add(this.cbDatabase);
             this.Controls.Add(this.lnkVersion);
             this.Controls.Add(this.txtLog);
@@ -146,6 +166,8 @@
         private System.Windows.Forms.PictureBox pictureBox1;
         private System.Windows.Forms.PictureBox WaitImage;
         private System.Windows.Forms.ComboBox cbDatabase;
+        private System.Windows.Forms.TextBox txtBackupAs;
+        private System.Windows.Forms.Label label2;
 
     }
 }

--- a/src/DataButler/Backup.cs
+++ b/src/DataButler/Backup.cs
@@ -52,7 +52,6 @@ namespace DataButler
             txtLog.Visible = true;
             txtLog.Clear();
             Cursor = Cursors.WaitCursor;
-           // btnBackup.Enabled = cbDatabase.Enabled = false;
             WaitImage.Visible = true;
             _backgroundWorker.RunWorkerAsync(cbDatabase.SelectedItem as SqlDatabase);
         }

--- a/src/DataButler/Backup.cs
+++ b/src/DataButler/Backup.cs
@@ -11,7 +11,7 @@ namespace DataButler
     public partial class Backup : Form
     {
         readonly BackgroundWorker _backgroundWorker = new BackgroundWorker { WorkerReportsProgress = true };
-        string databaseBackupName;
+        public string userBackupName;
         public Backup()
         {
             InitializeComponent();
@@ -58,9 +58,9 @@ namespace DataButler
 
         private void BackgroundWorkerOnDoWork(object sender, DoWorkEventArgs e)
         {
-            databaseBackupName = txtBackupAs.Text;
+            userBackupName = txtBackupAs.Text;
             var database = e.Argument as SqlDatabase;
-            e.Result = Database.Backup(database, databaseBackupName, _backgroundWorker);
+            e.Result = Database.Backup(database, userBackupName, _backgroundWorker);
         }
 
         private void BackgroundWorkerOnRunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)

--- a/src/DataButler/Backup.cs
+++ b/src/DataButler/Backup.cs
@@ -11,6 +11,7 @@ namespace DataButler
     public partial class Backup : Form
     {
         readonly BackgroundWorker _backgroundWorker = new BackgroundWorker { WorkerReportsProgress = true };
+        string databaseBackupName;
         public Backup()
         {
             InitializeComponent();
@@ -51,15 +52,16 @@ namespace DataButler
             txtLog.Visible = true;
             txtLog.Clear();
             Cursor = Cursors.WaitCursor;
-            btnBackup.Enabled = cbDatabase.Enabled = false;
+           // btnBackup.Enabled = cbDatabase.Enabled = false;
             WaitImage.Visible = true;
             _backgroundWorker.RunWorkerAsync(cbDatabase.SelectedItem as SqlDatabase);
         }
 
         private void BackgroundWorkerOnDoWork(object sender, DoWorkEventArgs e)
         {
+            databaseBackupName = txtBackupAs.Text;
             var database = e.Argument as SqlDatabase;
-            e.Result = Database.Backup(database, _backgroundWorker);
+            e.Result = Database.Backup(database, databaseBackupName, _backgroundWorker);
         }
 
         private void BackgroundWorkerOnRunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)

--- a/src/DataButler/Utilities/Database.cs
+++ b/src/DataButler/Utilities/Database.cs
@@ -74,10 +74,11 @@ namespace DataButler.Utilities
             }
         }
 
-        public static string Backup(SqlDatabase database, BackgroundWorker backgroundWorker = null)
+        public static string Backup(SqlDatabase database, string databaseBackupName, BackgroundWorker backgroundWorker = null)
         {
             string result;
-            var fileName = GetBackupFileName(database);
+            var newName = databaseBackupName;
+            var fileName = GetBackupFileName(database, newName);
             _bgw = backgroundWorker;
             using (var con = (SqlConnection)OpenConnection())
             {
@@ -88,12 +89,12 @@ namespace DataButler.Utilities
             return result;
         }
 
-        static string GetBackupFileName(SqlDatabase database)
+        static string GetBackupFileName(SqlDatabase database, string newName)
         {
             var backupDir = string.IsNullOrEmpty(database.LastBackupName)
                 ? @"C:\temp\"
                 : Path.GetDirectoryName(database.LastBackupName);
-            var backupName = string.Format("{0}{1}", database.Name, DateTime.Now.ToString("yyyyMMddHHmm"));
+            var backupName = SetBackupName(database, newName);
             var fullBackupName = Path.Combine(backupDir, string.Format("{0}.bak", backupName));
             var copyCount = 0;
             while (File.Exists(fullBackupName))
@@ -101,6 +102,13 @@ namespace DataButler.Utilities
                 fullBackupName = Path.Combine(backupDir, string.Format("{0}_Copy{1}.bak", backupName, ++copyCount));
             }
             return fullBackupName;
+        }
+
+        static object SetBackupName(SqlDatabase database, string newName)
+        {
+            return string.IsNullOrWhiteSpace(newName)
+                ? string.Format("{0}, {1}", database.Name, DateTime.Now.ToString("yyyyMMddHHmm"))
+                :  newName;
         }
 
         public static string GetDatabaseName(string file, out string failure)

--- a/src/DataButler/Utilities/Database.cs
+++ b/src/DataButler/Utilities/Database.cs
@@ -74,11 +74,10 @@ namespace DataButler.Utilities
             }
         }
 
-        public static string Backup(SqlDatabase database, string databaseBackupName, BackgroundWorker backgroundWorker = null)
+        public static string Backup(SqlDatabase database, string userBackupName, BackgroundWorker backgroundWorker = null)
         {
             string result;
-            var newName = databaseBackupName;
-            var fileName = GetBackupFileName(database, newName);
+            var fileName = GetBackupFileName(database, userBackupName);
             _bgw = backgroundWorker;
             using (var con = (SqlConnection)OpenConnection())
             {
@@ -89,12 +88,12 @@ namespace DataButler.Utilities
             return result;
         }
 
-        static string GetBackupFileName(SqlDatabase database, string newName)
+        static string GetBackupFileName(SqlDatabase database, string userBackupName)
         {
             var backupDir = string.IsNullOrEmpty(database.LastBackupName)
                 ? @"C:\temp\"
                 : Path.GetDirectoryName(database.LastBackupName);
-            var backupName = SetBackupName(database, newName);
+            var backupName = SetBackupName(database.Name, userBackupName);
             var fullBackupName = Path.Combine(backupDir, string.Format("{0}.bak", backupName));
             var copyCount = 0;
             while (File.Exists(fullBackupName))
@@ -104,11 +103,11 @@ namespace DataButler.Utilities
             return fullBackupName;
         }
 
-        static object SetBackupName(SqlDatabase database, string newName)
+        public static object SetBackupName(string databaseName, string userBackupName)
         {
-            return string.IsNullOrWhiteSpace(newName)
-                ? string.Format("{0}, {1}", database.Name, DateTime.Now.ToString("yyyyMMddHHmm"))
-                :  newName;
+            return string.IsNullOrWhiteSpace(userBackupName)
+                ? string.Format("{0}, {1}", databaseName, DateTime.Now.ToString("yyyyMMddHHmm"))
+                :  userBackupName;
         }
 
         public static string GetDatabaseName(string file, out string failure)

--- a/src/DataButler/Utilities/SqlDatabase.cs
+++ b/src/DataButler/Utilities/SqlDatabase.cs
@@ -10,7 +10,7 @@
             LastBackupName = lastBackupName;
         }
 
-        public string Name { get; private set; }
+        public string Name { get; set; }
         public string LastBackupName { get; set; }
         public override string ToString()
         {

--- a/src/DataButlerTests/DataAccessTests.cs
+++ b/src/DataButlerTests/DataAccessTests.cs
@@ -20,7 +20,7 @@ namespace DataButlerTests
         {
             string failure;
             var name = Database.GetDatabaseName(SampleBackup, out failure);
-            Assert.AreEqual("IddealDemo", name);
+            Assert.AreEqual("Sample", name);
         }
         [Test]
         public void CanRestoreToNonExistingDatabase()


### PR DESCRIPTION
This resolves an issue preventing the user to rename a database backup with DataButler.
This also leaves the `Backup` button enabled after the backup so the user can backup repeatedly without the need to close and re-open the backup form.